### PR TITLE
Fix Page Response not usually containing body attribute passed to cheerio

### DIFF
--- a/form-scraper.js
+++ b/form-scraper.js
@@ -13,7 +13,7 @@ _.extend(ScrapingFormProvider, {
       .then(fetchFormDataFromHttpResponse);
 
     function fetchFormDataFromHttpResponse(response) {
-      $ = cheerio.load(response.body);
+      $ = response.body?cheerio.load(response.body):cheerio.load(response);
       var formDom = $(formId);
 
       if (isFormAbsent(formDom))


### PR DESCRIPTION
Check if page response contains body, if not pass response as body to cheerio.
